### PR TITLE
suggested fix for issue #2

### DIFF
--- a/jarjarbigs.py
+++ b/jarjarbigs.py
@@ -74,7 +74,10 @@ def extract_archive(archive_file):
 	temp_dir = tempfile.mkdtemp(prefix = "jarjarbigs")
 
 	archive = zipfile.ZipFile(archive_file, 'r')
-	archive.extractall(temp_dir)
+	try:
+		archive.extractall(temp_dir)
+	except FileExistsError as file_exists_error:
+		print("[-] Warning! The archive \"{archive_file}\" seems to have a broken file structure. Found douplicate file when trying to write to \"{error_filepath}\". Continuing anyway, result most likely incomplete (please check the contents of the affected archive).".format(archive_file=archive_file, error_filepath=str(file_exists_error.filename)))
 
 	directories = [temp_dir]
 


### PR DESCRIPTION
A suggested fix for issue #2 . 

The fix just catches the error and prints a warning.

Pros:
* quick to implement
* don't have to rewrite the unpacking because the zip library doesn't support this case

Cons:
* So far I have only encountered this issue with the /META/ path. The current solution just discards that the META folder can't be written, so we loose some information here
* Because the warning is in the middle of processing the warning might get lost in the stream of extracted files
