### PR TITLE
Support classes in Sring Boot applications

### DIFF
--- a/jarjarbigs.py
+++ b/jarjarbigs.py
@@ -30,6 +30,7 @@ def copy_class_files(archive, source, destination):
 	for class_file in class_files:
 		current_path = os.path.dirname(class_file)[len(source):]
 		current_path = current_path.replace('WEB-INF/classes/', '')
+		current_path = current_path.replace('BOOT-INF/classes/', '')
 		current_file = os.path.basename(class_file)
 		destination_path = destination + current_path
 		if not destination_path.endswith("/"):


### PR DESCRIPTION
This pull requests adds support for classes that are part of a Spring Boot JAR.
A Spring-Boot project stores classes in "BOOT-INF/classes" which was skipped by jarjarbigs.
